### PR TITLE
Add Database creation steps to documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,6 +12,7 @@ Usual OAuth2.0 Workflow steps:
 # First time setup
 
 Create the database:
+
     $ mkdir db
     $ cd db
     $ sqlite3 oauth2server_dev_db.sqlite

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,9 +12,9 @@ Usual OAuth2.0 Workflow steps:
 # First time setup
 
 Create the database:
-  $ mkdir db
-  $ cd db
-  $ sqlite3 oauth2server_dev_db.sqlite
+    $ mkdir db
+    $ cd db
+    $ sqlite3 oauth2server_dev_db.sqlite
 
 
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,6 +11,13 @@ Usual OAuth2.0 Workflow steps:
 
 # First time setup
 
+Create the database:
+  $ mkdir db
+  $ cd db
+  $ sqlite3 oauth2server_dev_db.sqlite
+
+
+
 Start the server:
 
     $ sbt "run 9002"


### PR DESCRIPTION
I tried to run the application on my Mac running OS X 10.10 (Yosemite) and I got the following error:

play.api.Configuration$$anon$1: Configuration error[Cannot connect to database [default]]

I created the db directory and then created the database using sqlite3 command then ran the script that was provided.  I added the steps I took to get the database created to the documentation.
